### PR TITLE
Simplify promises

### DIFF
--- a/src/components/touch-entropy/touch-entropy.ts
+++ b/src/components/touch-entropy/touch-entropy.ts
@@ -71,40 +71,36 @@ export class TouchEntropyComponent implements OnInit, IEntropyGenerator {
 
   start(): Promise<void> {
     this.collectedEntropyPercentage = 0
-    return new Promise((resolve, reject) => {
-      this.renderer.listen(this.canvas, 'mousedown', (e) => {
-        this.isDrawing = true
-      })
-
-      this.renderer.listen(this.canvas, 'touchstart', (e) => {
-        this.isDrawing = true
-      })
-
-      this.renderer.listen(this.canvas, 'mouseup', (e) => {
-        this.isDrawing = false
-      })
-
-      this.renderer.listen(this.canvas, 'touchend', (e) => {
-        this.isDrawing = false
-      })
-
-      this.renderer.listen(this.canvas, 'mousemove', (e) => {
-        if (this.isDrawing) this.collectEntropy(e)
-      })
-
-      this.renderer.listen(this.canvas, 'touchmove', (e) => {
-        if (this.isDrawing) this.collectEntropy(e)
-      })
-
-      resolve()
+    this.renderer.listen(this.canvas, 'mousedown', (e) => {
+      this.isDrawing = true
     })
+
+    this.renderer.listen(this.canvas, 'touchstart', (e) => {
+      this.isDrawing = true
+    })
+
+    this.renderer.listen(this.canvas, 'mouseup', (e) => {
+      this.isDrawing = false
+    })
+
+    this.renderer.listen(this.canvas, 'touchend', (e) => {
+      this.isDrawing = false
+    })
+
+    this.renderer.listen(this.canvas, 'mousemove', (e) => {
+      if (this.isDrawing) this.collectEntropy(e)
+    })
+
+    this.renderer.listen(this.canvas, 'touchmove', (e) => {
+      if (this.isDrawing) this.collectEntropy(e)
+    })
+
+    return Promise.resolve()
   }
 
   stop(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.isDrawing = false
-      resolve()
-    })
+    this.isDrawing = false
+    return Promise.resolve()
   }
 
   collectEntropy(e) {

--- a/src/providers/audio/audio.browser.service.ts
+++ b/src/providers/audio/audio.browser.service.ts
@@ -63,11 +63,9 @@ export class AudioBrowserService implements IEntropyGenerator {
   }
 
   stop(): Promise<any> {
-    return new Promise((resolve, reject) => {
-      this.microphoneStreamSource.disconnect()
-      this.scriptProcessor.disconnect()
-      resolve()
-    })
+    this.microphoneStreamSource.disconnect()
+    this.scriptProcessor.disconnect()
+    return Promise.resolve()
   }
 
   getEntropyUpdateObservable(): Observable<Entropy> {

--- a/src/providers/audio/audio.native.service.ts
+++ b/src/providers/audio/audio.native.service.ts
@@ -39,31 +39,25 @@ export class AudioNativeService implements IEntropyGenerator {
 
   start(): Promise<void> {
     this.collectedEntropyPercentage = 0
-    return new Promise((resolve, reject) => {
-      this.platform.ready().then(() => {
+    return this.platform.ready().then(() => {
 
-        window.audioinput.start({
-          bufferSize: this.ENTROPY_SIZE
-        })
-
-        setTimeout(() => {
-          window.addEventListener('audioinput', this.handler)
-        }, 1000)
-
-        console.log('audioinput created.')
-
-        resolve()
+      window.audioinput.start({
+        bufferSize: this.ENTROPY_SIZE
       })
+
+      setTimeout(() => {
+        window.addEventListener('audioinput', this.handler)
+      }, 1000)
+
+      console.log('audioinput created.')
     })
   }
 
   stop(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      console.log('removed audioinput listener')
-      window.audioinput.stop()
-      window.removeEventListener('audioinput', this.handler)
-      resolve()
-    })
+    console.log('removed audioinput listener')
+    window.audioinput.stop()
+    window.removeEventListener('audioinput', this.handler)
+    return Promise.resolve()
   }
 
   getEntropyUpdateObservable(): Observable<Entropy> {

--- a/src/providers/camera/camera.native.service.ts
+++ b/src/providers/camera/camera.native.service.ts
@@ -69,10 +69,8 @@ export class CameraNativeService implements IEntropyGenerator {
   start(): Promise<void> {
     this.disabled = false
     this.collectedEntropyPercentage = 0
-    return new Promise((resolve, reject) => {
-      this.platform.ready().then(() => {
-        resolve(this.initCamera())
-      })
+    return this.platform.ready().then(() => {
+      return this.initCamera()
     })
   }
 
@@ -151,25 +149,22 @@ export class CameraNativeService implements IEntropyGenerator {
     // if it is called while taking a photo
     if (this.cameraIsTakingPhoto) {
       this.uninjectCSS()
-      return new Promise((resolve, reject) => {
-        setTimeout(() => {
-          console.log('CAMERA IS TAKING PHOTO, DELAYING')
-          return this.stop()
-        }, 200)
-      })
+      setTimeout(() => {
+        console.log('CAMERA IS TAKING PHOTO, DELAYING')
+        this.stop()
+      }, 200)
+      return new Promise(() => {})
     }
     this.uninjectCSS()
     if (this.cameraInterval) {
       clearInterval(this.cameraInterval)
     }
-    return new Promise((resolve, reject) => {
-      this.cameraPreview.stopCamera().then(() => {
-        this.cameraIsRunning = false
-        console.log('camera stopped.')
-      }, error => {
-        console.log('camera could not be stopped.')
-        reject(error)
-      })
+    return this.cameraPreview.stopCamera().then(() => {
+      this.cameraIsRunning = false
+      console.log('camera stopped.')
+    }, error => {
+      console.log('camera could not be stopped.')
+      return Promise.reject(error)
     })
   }
 

--- a/src/providers/entropy/entropy.service.ts
+++ b/src/providers/entropy/entropy.service.ts
@@ -60,26 +60,22 @@ export class EntropyService {
 
   stopEntropyCollection(): Promise<void> {
     let promises = []
-    return new Promise((resolve, reject) => {
-      // clear collection interval
-      for (let i = 0; i < this.entropySubscriptions.length; i++) {
-        this.entropySubscriptions[i].unsubscribe()
-      }
+    // clear collection interval
+    for (let i = 0; i < this.entropySubscriptions.length; i++) {
+      this.entropySubscriptions[i].unsubscribe()
+    }
 
-      this.entropySubscriptions = []
+    this.entropySubscriptions = []
 
-      // stop entropy sources
-      for (let i = 0; i < this.entropyGenerators.length; i++) {
-        console.log('stopping entropy source...')
-        promises.push(this.entropyGenerators[i].stop())
-      }
+    // stop entropy sources
+    for (let i = 0; i < this.entropyGenerators.length; i++) {
+      console.log('stopping entropy source...')
+      promises.push(this.entropyGenerators[i].stop())
+    }
 
-      this.entropyGenerators = []
+    this.entropyGenerators = []
 
-      Promise.all(promises).then(() => {
-        resolve()
-      })
-    })
+    return Promise.all(promises).then(() => {})
   }
 
   getEntropyAsHex(): Promise<string> {

--- a/src/providers/gyroscope/gyroscope.native.service.ts
+++ b/src/providers/gyroscope/gyroscope.native.service.ts
@@ -24,21 +24,18 @@ export class GyroscopeNativeService implements GyroscopeService, IEntropyGenerat
 
   public start(): Promise<void> {
     this.collectedEntropyPercentage = 0
-    return new Promise((resolve, reject) => {
-      this.platform.ready().then(() => {
-        this.entropyObservable = new Observable(observer => {
-          this.gyroSubscription = this.deviceMotion.watchAcceleration({ frequency: 500 }).subscribe((acceleration: DeviceMotionAccelerationData) => {
-            const entropyBuffer = this.arrayBufferFromIntArray([acceleration.x, acceleration.y, acceleration.z])
-            entropyCalculatorWorker.onmessage = (event) => {
-              this.collectedEntropyPercentage += event.data.entropyMeasure
-              observer.next({
-                entropyHex: event.data.entropyHex
-              })
-            }
-            entropyCalculatorWorker.postMessage({ entropyBuffer: entropyBuffer }, [entropyBuffer])
-          })
+    return this.platform.ready().then(() => {
+      this.entropyObservable = new Observable(observer => {
+        this.gyroSubscription = this.deviceMotion.watchAcceleration({ frequency: 500 }).subscribe((acceleration: DeviceMotionAccelerationData) => {
+          const entropyBuffer = this.arrayBufferFromIntArray([acceleration.x, acceleration.y, acceleration.z])
+          entropyCalculatorWorker.onmessage = (event) => {
+            this.collectedEntropyPercentage += event.data.entropyMeasure
+            observer.next({
+              entropyHex: event.data.entropyHex
+            })
+          }
+          entropyCalculatorWorker.postMessage({ entropyBuffer: entropyBuffer }, [entropyBuffer])
         })
-        resolve()
       })
     })
   }


### PR DESCRIPTION
As I know, there is no difference between
```js
return new Promise(resolve => resolve())
```
and
```js
return Promise.resolve()
```
but the second option is much easier to read in most cases, I think you should use it.