### PR TITLE
feat(ios): add aepp-base to LSApplicationQueriesSchemes

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -50,6 +50,7 @@
         <edit-config file="*-Info.plist" mode="merge" target="LSApplicationQueriesSchemes">
             <array>
                 <string>airgap-wallet</string>
+                <string>aepp-base</string>
             </array>
         </edit-config>
         <edit-config file="*-Info.plist" mode="merge" target="NSFaceIDUsageDescription">


### PR DESCRIPTION
I'm proposing to allow AirGap Vault to open Base Aepp by scheme to finish AirGap integration on same device. I'm using the same plugin as you do for opening apps (https://github.com/lampaa/com.lampa.startapp). It's using canOpenUrl function (https://developer.apple.com/documentation/uikit/uiapplication/1622952-canopenurl) which returns false for all schemes except the ones which registered in LSApplicationQueriesSchemes requirement in Info.plist.