### PR TITLE
fix: don't break iteraction urls with a custom prefix

### DIFF
--- a/src/app/pages/account-share/account-share.page.ts
+++ b/src/app/pages/account-share/account-share.page.ts
@@ -15,7 +15,7 @@ export class AccountSharePage {
 
   constructor(private readonly navigationService: NavigationService) {
     this.interactionUrl = this.navigationService.getState().interactionUrl
-    this.splits = this.interactionUrl.substr('airgap-wallet://?d='.length).split(',')
+    this.splits = this.interactionUrl.replace(/^airgap-wallet:\/\/\?d=/, '').split(',')
   }
 
   public done(): void {

--- a/src/app/pages/transaction-signed/transaction-signed.page.ts
+++ b/src/app/pages/transaction-signed/transaction-signed.page.ts
@@ -33,7 +33,7 @@ export class TransactionSignedPage {
 
   constructor(public navigationService: NavigationService, private readonly translateService: TranslateService) {
     this.interactionUrl = this.navigationService.getState().interactionUrl
-    this.splits = this.interactionUrl.substr('airgap-wallet://?d='.length).split(',')
+    this.splits = this.interactionUrl.replace(/^airgap-wallet:\/\/\?d=/, '').split(',')
     this.wallets = this.navigationService.getState().wallets
     this.signedTxs = this.navigationService.getState().signedTxs
     this.translationKey = this.navigationService.getState().translationKey


### PR DESCRIPTION
In the Base aepp, we are using a custom one: https://github.com/aeternity/aepp-base/blob/4a6b929c4e01a8d9ce1b3a0a1e4e6f4e6c16258a/src/lib/airGap.js#L6

The URL breaks this way: `airgap-wallet://?d=com/airgap?d=UgoPLk4k...`