### PR TITLE
fix issue 243, app built on Windows cannot find manifest.json at startup and hangs on logo screen.

### DIFF
--- a/copy-builtin-modules.js
+++ b/copy-builtin-modules.js
@@ -57,7 +57,7 @@ const communityModules = [{ path: path.join(rootdir, 'node_modules/@airgap-commu
 
 function createAirGapModule(module) {
   const packageJson = require(`./${path.join(module.path, 'package.json')}`)
-  const namespace = module.path.split('/').slice(-1)[0]
+  const namespace = path.basename(module.path)
   const outputDir = path.join(assetsdir, `protocol_modules/${namespace}`)
   const outputFile = 'index.browserify.js'
 
@@ -84,7 +84,7 @@ function createAirGapModule(module) {
 }
 
 function copyCommunityModule(module) {
-  const namespace = module.path.split('/').slice(-1)[0]
+  const namespace = path.basename(module.path)
   const outputDir = path.join(assetsdir, `protocol_modules/${namespace}`)
 
   fs.mkdirSync(outputDir, { recursive: true })


### PR DESCRIPTION
Use a system-independent path separator to get namespace name, otherwise building the project on Windows will generate incorrect manifest.json asset paths
```public/assets/protocol_modules/node_modules/@airgap-community/iso-rootstock/manifest.json```
causing the app to hang at startup on the device because it cannot find manifest.json
```public/assets/protocol_modules/iso-rootstock/manifest.json```

On the Windows platform, the path separator is '\\\\' instead of '/'
This issue causes the app to hang on the logo screen at startup.


fix issue https://github.com/airgap-it/airgap-vault/issues/243