### PR TITLE
Replaces #297 - Add wallet labels, display master fingerprint, fix Windows build and Sonar issues

### DIFF
--- a/copy-builtin-modules.js
+++ b/copy-builtin-modules.js
@@ -57,7 +57,7 @@ const communityModules = [{ path: path.join(rootdir, 'node_modules/@airgap-commu
 
 function createAirGapModule(module) {
   const packageJson = require(`./${path.join(module.path, 'package.json')}`)
-  const namespace = module.path.split('/').slice(-1)[0]
+  const namespace = path.basename(module.path)
   const outputDir = path.join(assetsdir, `protocol_modules/${namespace}`)
   const outputFile = 'index.browserify.js'
 
@@ -84,7 +84,8 @@ function createAirGapModule(module) {
 }
 
 function copyCommunityModule(module) {
-  const namespace = module.path.split('/').slice(-1)[0]
+  console.log('MODULE PATH:', module.path)
+  const namespace = path.basename(module.path)
   const outputDir = path.join(assetsdir, `protocol_modules/${namespace}`)
 
   fs.mkdirSync(outputDir, { recursive: true })

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -129,3 +129,12 @@ pre {
 .transparent {
   --background: none transparent !important;
 }
+
+airgap-account-item ion-label div {
+  display: block !important;
+}
+
+airgap-account-item ion-label div p {
+  text-align: left;
+  margin-left: 0;
+}

--- a/src/app/pages/account-add/account-add.page.html
+++ b/src/app/pages/account-add/account-add.page.html
@@ -57,6 +57,17 @@
         <ion-checkbox [(ngModel)]="singleSelectedProtocol.isHDWallet" (ionChange)="toggleHDWallet()" slot="end"></ion-checkbox>
       </ion-item>
 
+      <ion-item class="ion-no-padding" lines="full">
+     <ion-label position="stacked" color="primary">
+      Nome da conta
+      </ion-label>
+
+     <ion-input
+      [(ngModel)]="accountLabel"
+      placeholder="Ex.: Carteira 10"
+     ></ion-input>
+      </ion-item>
+
       <ng-container *ngIf="isBip39PassphraseEnabled">
         <ion-item class="ion-no-padding" *ngIf="isBip39PassphraseEnabled" lines="full">
           <ion-label position="stacked" color="primary">BIP-39 Passphrase</ion-label>

--- a/src/app/pages/account-add/account-add.page.ts
+++ b/src/app/pages/account-add/account-add.page.ts
@@ -46,6 +46,7 @@ export class AccountAddPage {
   public isBip39PassphraseEnabled: boolean = BIP39_PASSPHRASE_ENABLED
   public revealBip39Passphrase: boolean = false
   public bip39Passphrase: string = ''
+  public accountLabel: string = ''
 
   public isAppAdvancedMode$: Observable<boolean> = this.storageService
     .subscribe(VaultStorageKey.ADVANCED_MODE_TYPE)
@@ -182,12 +183,13 @@ export class AccountAddPage {
             selectedProtocols.map(async (protocolWrapper: ProtocolWrapper) => {
               const protocol = protocolWrapper.protocol
               return {
-                protocolIdentifier: await protocol.getIdentifier(),
-                isHDWallet: protocolWrapper.isHDWallet,
-                customDerivationPath: protocolWrapper.customDerivationPath ?? (await protocol.getStandardDerivationPath()),
-                bip39Passphrase: this.bip39Passphrase,
-                isActive: true
-              }
+             protocolIdentifier: await protocol.getIdentifier(),
+             isHDWallet: protocolWrapper.isHDWallet,
+             customDerivationPath: protocolWrapper.customDerivationPath ?? (await protocol.getStandardDerivationPath()),
+             bip39Passphrase: this.bip39Passphrase,
+             isActive: true,
+             label: this.accountLabel
+            }
             })
           )
         )

--- a/src/app/pages/account-address/account-address.page.html
+++ b/src/app/pages/account-address/account-address.page.html
@@ -34,9 +34,19 @@
         <span class="selectable typography--mono">{{ wallet.derivationPath }}</span>
       </p>
       <p *ngIf="isAppAdvancedMode$ | async">
-        <ion-chip color="light" *ngIf="wallet.isExtendedPublicKey">HD Wallet</ion-chip>
-        <ion-chip color="light" *ngIf="secret.fingerprint !== wallet.masterFingerprint">BIP39 passphrase</ion-chip>
-      </p>
+  <ion-chip color="light" *ngIf="wallet.isExtendedPublicKey">
+    HD Wallet
+  </ion-chip>
+
+  <ion-chip color="light" *ngIf="wallet.masterFingerprint">
+    Master Fingerprint:
+    {{ wallet.masterFingerprint }}
+  </ion-chip>
+
+  <ion-chip color="light" *ngIf="secret.fingerprint !== wallet.masterFingerprint">
+    BIP39 Passphrase
+  </ion-chip>
+</p>
     </ion-col>
   </ion-row>
 

--- a/src/app/pages/accounts-list/accounts-list.page.html
+++ b/src/app/pages/accounts-list/accounts-list.page.html
@@ -31,12 +31,12 @@
           <ng-container *ngIf="deleteView">
             <ion-item>
               <ion-checkbox slot="start" (ionChange)="onWalletSelected($event, wallet)"></ion-checkbox>
-              <airgap-account-item [wallet]="wallet" (click)="goToReceiveAddress(wallet)"></airgap-account-item>
+              <airgap-account-item [wallet]="wallet" [label]="wallet.label" (click)="goToReceiveAddress(wallet)"></airgap-account-item>
             </ion-item>
           </ng-container>
 
           <ng-container *ngIf="!deleteView">
-            <airgap-account-item [wallet]="wallet" (click)="goToReceiveAddress(wallet)"></airgap-account-item>
+            <airgap-account-item [wallet]="wallet" [label]="wallet.label" (click)="goToReceiveAddress(wallet)"></airgap-account-item>
           </ng-container>
           <ion-item-options side="end">
             <ion-item-option (click)="delete(wallet)">

--- a/src/app/pages/accounts-list/accounts-list.page.html
+++ b/src/app/pages/accounts-list/accounts-list.page.html
@@ -31,12 +31,24 @@
           <ng-container *ngIf="deleteView">
             <ion-item>
               <ion-checkbox slot="start" (ionChange)="onWalletSelected($event, wallet)"></ion-checkbox>
-              <airgap-account-item [wallet]="wallet" [label]="wallet.label" (click)="goToReceiveAddress(wallet)"></airgap-account-item>
+              <airgap-account-item
+                [wallet]="wallet"
+                [label]="wallet.label"
+                tabindex="0"
+                (click)="goToReceiveAddress(wallet)"
+                (keydown.enter)="goToReceiveAddress(wallet)">
+</airgap-account-item>
             </ion-item>
           </ng-container>
 
           <ng-container *ngIf="!deleteView">
-            <airgap-account-item [wallet]="wallet" [label]="wallet.label" (click)="goToReceiveAddress(wallet)"></airgap-account-item>
+            <airgap-account-item
+                 [wallet]="wallet"
+                 [label]="wallet.label"
+                 tabindex="0"
+                 (click)="goToReceiveAddress(wallet)"
+                 (keydown.enter)="goToReceiveAddress(wallet)">
+</airgap-account-item>
           </ng-container>
           <ion-item-options side="end">
             <ion-item-option (click)="delete(wallet)">

--- a/src/app/services/iac/iac.service.ts
+++ b/src/app/services/iac/iac.service.ts
@@ -330,6 +330,7 @@ export class IACService extends BaseIACService {
           baseWallet.status
         )
         correctWallet.addresses = baseWallet.addresses
+        correctWallet.label = baseWallet.label
       } catch (e) {
         if (e.message === 'PROTOCOL_NOT_SUPPORTED') {
           correctWallet = baseWallet

--- a/src/app/services/secrets/secrets.service.ts
+++ b/src/app/services/secrets/secrets.service.ts
@@ -53,6 +53,7 @@ interface AddWalletConifg {
   customDerivationPath: string
   bip39Passphrase: string
   isActive: boolean
+  label?: string
 }
 @Injectable({
   providedIn: 'root'
@@ -624,6 +625,7 @@ export class SecretsService {
 
     const addresses: string[] = await wallet.deriveAddresses(1)
     wallet.addresses = addresses
+    wallet.label = config.label
 
     return wallet
   }

--- a/src/app/services/secrets/secrets.service.ts
+++ b/src/app/services/secrets/secrets.service.ts
@@ -126,6 +126,7 @@ export class SecretsService {
                 serializedWallet.status ?? AirGapWalletStatus.ACTIVE
               )
               airGapWallet.addresses = serializedWallet.addresses
+              airGapWallet.label = serializedWallet.label
               return airGapWallet
             })
           )

--- a/src/app/services/secrets/secrets.service.ts
+++ b/src/app/services/secrets/secrets.service.ts
@@ -301,13 +301,30 @@ export class SecretsService {
 
     if (isBtc) {
       // BTC protocols: Always HD, increment account index
-      const lastIndices = existingWallets.map((wallet) => {
-        const match = wallet.derivationPath.match(/(\d+)[h']?\/?$/)
-        return match ? parseInt(match[1], 10) : 0
+
+        const lastIndices = existingWallets.map((wallet) => {
+        const lastPart = wallet.derivationPath.split('/').pop() ?? ''
+        const index = lastPart.replace(/[h']/g, '')
+
+        return Number(index) || 0
       })
       const maxIndex = Math.max(...lastIndices)
       const nextIndex = maxIndex + 1
-      const newPath = standardPath.replace(/(\d+)([h']?)(\/?)?$/, `${nextIndex}$2$3`)
+      const parts = standardPath.split('/')
+      const last = parts.pop() ?? ''
+
+      let suffix = ''
+
+      if (last.endsWith("'")) {
+      suffix = "'"
+      } else if (last.endsWith('h')) {
+      suffix = 'h'
+     }
+
+      parts.push(`${nextIndex}${suffix}`)
+
+      const newPath = parts.join('/')
+
       return { derivationPath: newPath, isHDWallet: true }
     } else if (supportsHD) {
       // HD-capable protocols (ETH, OP, etc.): First is HD, subsequent are non-HD
@@ -318,8 +335,10 @@ export class SecretsService {
           return 0
         }
         // Non-HD wallet - extract last number from path
-        const match = wallet.derivationPath.match(/\/(\d+)$/)
-        return match ? parseInt(match[1], 10) : 0
+        const lastPart = wallet.derivationPath.split('/').pop() ?? ''
+        const index = lastPart.replace(/[h']/g, '')
+
+        return Number(index) || 0
       })
       const maxIndex = Math.max(...addressIndices)
       const nextIndex = maxIndex + 1
@@ -333,7 +352,22 @@ export class SecretsService {
       })
       const maxIndex = Math.max(...lastIndices)
       const nextIndex = maxIndex + 1
-      const newPath = standardPath.replace(/(\d+)([h']?)(\/?)?$/, `${nextIndex}$2$3`)
+
+      const parts = standardPath.split('/')
+      const last = parts.pop() ?? ''
+
+      let suffix = ''
+
+      if (last.endsWith("'")) {
+      suffix = "'"
+      } else if (last.endsWith('h')) {
+      suffix = 'h'
+     }
+
+      parts.push(`${nextIndex}${suffix}`)
+
+      const newPath = parts.join('/')
+
       return { derivationPath: newPath, isHDWallet: false }
     }
   }

--- a/src/app/services/secrets/secrets.service.ts
+++ b/src/app/services/secrets/secrets.service.ts
@@ -127,6 +127,7 @@ export class SecretsService {
               )
               airGapWallet.addresses = serializedWallet.addresses
               airGapWallet.label = serializedWallet.label
+              
               return airGapWallet
             })
           )
@@ -496,8 +497,12 @@ export class SecretsService {
         if (storedSecret === undefined) {
           return secret
         }
-        const wallets: SerializedAirGapWallet[] = await Promise.all(secret.wallets.slice(0).map((wallet: AirGapWallet) => wallet.toJSON()))
-        for (let i = 0; i < storedSecret.wallets.length; ++i) {
+         
+        const wallets: SerializedAirGapWallet[] = await Promise.all(
+         secret.wallets.slice(0).map((wallet: AirGapWallet) => wallet.toJSON())
+         )
+         
+         for (let i = 0; i < storedSecret.wallets.length; ++i) {
           const serializedWallet = storedSecret.wallets[i] as unknown as SerializedAirGapWallet
 
           const filtered: (AirGapWallet | SerializedAirGapWallet | undefined)[] = await Promise.all(
@@ -515,9 +520,20 @@ export class SecretsService {
             wallets.push(serializedWallet)
           }
         }
+     
         const result = MnemonicSecret.init(secret)
-        result.wallets = wallets as unknown as AirGapWallet[]
-        return result
+       result.wallets = wallets.map((wallet: SerializedAirGapWallet) => {
+       const original = secret.wallets.find(
+       (w) => w.publicKey === wallet.publicKey
+  )
+
+  return {
+    ...wallet,
+    label: original?.label ?? wallet.label ?? ''
+  } as unknown as AirGapWallet
+})
+
+return result
       })
     )
 


### PR DESCRIPTION
This PR includes three improvements.

1. Windows build fix
Problem
The Android build generated an invalid public/assets/protocol_modules structure on Windows because the namespace was extracted using module.path.split('/'), which does not work with Windows path separators ().

Solution
Replaced the namespace extraction with path.basename(module.path), which works correctly on both Windows and Linux.

2. Master Fingerprint display
Problem
When multiple wallets are created from the same mnemonic using different BIP-39 passphrases, users cannot easily verify which wallet they are viewing.

Solution
Display the wallet Master Fingerprint on the account details screen, allowing users to verify the correct wallet.

3. Custom wallet labels
Problem
When multiple accounts use the same protocol (for example several Bitcoin SegWit wallets), the account list only displays the protocol name and address, making it difficult to distinguish them.

Solution
Added support for custom wallet labels:

enter a label when creating a wallet;
persist the label during wallet serialization;
restore the label when deserializing the wallet;
display the label in the account list below the protocol name.