### PR TITLE
fix(): prevent iOS startup hang while loading protocol modules

### DIFF
--- a/ios/App/App/Helpers/JS.swift
+++ b/ios/App/App/Helpers/JS.swift
@@ -32,36 +32,22 @@ class JSAsyncResult: NSObject, Identifiable, WKScriptMessageHandler {
     private static let fieldError: String = "error"
     
     public let id: String
-    private var resultManager: ResultManager
     private let listenerRegistry: ListenerRegistry
     
     init(id: String = "\(JSAsyncResult.defaultName)\(Int(Date().timeIntervalSince1970))") {
         self.id = id
-        self.resultManager = .init()
         self.listenerRegistry = .init()
     }
     
     func createID() async -> String {
-        let id = await listenerRegistry.createID()
-        await listenerRegistry.add(forID: id) { [weak self] result in
-            let selfWeak = self
-            Task {
-                await selfWeak?.resultManager.setResult(result, forID: id)
-            }
-        }
-        
-        return id
+        await listenerRegistry.createID()
     }
     
     func awaitResultWithID(_ id: String) async throws -> Any {
         return try await withCheckedThrowingContinuation { continuation in
             Task {
-                if let result = await resultManager.result[id] {
+                await listenerRegistry.add(forID: id) { result in
                     continuation.resume(with: result)
-                } else {
-                    await listenerRegistry.add(forID: id) { result in
-                        continuation.resume(with: result)
-                    }
                 }
             }
         }
@@ -91,16 +77,9 @@ class JSAsyncResult: NSObject, Identifiable, WKScriptMessageHandler {
         }
     }
     
-    private actor ResultManager {
-        private(set) var result: [String: Result<Any, Error>] = [:]
-        
-        func setResult(_ result: Result<Any, Error>, forID id: String) {
-            self.result[id] = result
-        }
-    }
-    
     private actor ListenerRegistry {
         private(set) var listeners: [String: [Listener]] = [:]
+        private var results: [String: Result<Any, Error>] = [:]
         
         func createID() -> String {
             let id = UUID().uuidString
@@ -110,12 +89,23 @@ class JSAsyncResult: NSObject, Identifiable, WKScriptMessageHandler {
         }
         
         func add(forID id: String, _ listener: @escaping Listener) {
-            listeners[id]?.append(listener)
+            if let result = results.removeValue(forKey: id) {
+                listener(result)
+            } else if listeners[id] != nil {
+                listeners[id]?.append(listener)
+            } else {
+                listener(.failure(JSError.unknownResultID(id)))
+            }
         }
         
         func notifyAllWithID(_ id: String, with result: Result<Any, Error>) {
-            listeners[id]?.forEach { $0(result) }
-            listeners.removeValue(forKey: id)
+            guard let listeners = listeners.removeValue(forKey: id) else { return }
+
+            if listeners.isEmpty {
+                results[id] = result
+            } else {
+                listeners.forEach { $0(result) }
+            }
         }
     }
 }
@@ -123,4 +113,5 @@ class JSAsyncResult: NSObject, Identifiable, WKScriptMessageHandler {
 enum JSError: Swift.Error {
     case invalidJSON
     case fromScript(Any)
+    case unknownResultID(String)
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -99,13 +99,13 @@ export class AppComponent implements AfterViewInit {
 
     if (this.platform.is('hybrid')) {
       this.statusBar.setStyle({ style: Style.Dark })
-      this.statusBar.setBackgroundColor({ color: '#311B58' })
       this.splashScreen.hide()
 
       await this.securityUtils.toggleAutomaticAuthentication({ automatic: true })
     }
 
     if (this.platform.is('android')) {
+      this.statusBar.setBackgroundColor({ color: '#311B58' })
       await EdgeToEdge.setBackgroundColor({ color: '#311B58' })
     }
 


### PR DESCRIPTION
## Summary

- make early JavaScript results and waiter registration atomic within one actor
- preserve results that arrive before `awaitResultWithID(_:)` registers its continuation
- restrict `StatusBar.setBackgroundColor` to Android, where the Capacitor API is implemented

## Root cause

iOS protocol-module loading evaluates JavaScript and then awaits a result by ID. The existing implementation split result storage and listener registration across two actors. A JavaScript result could arrive after the result lookup but before the waiter was registered. The notification then removed the listener entry, and the late continuation was never resumed, leaving startup permanently waiting on the native launch screen.

The reported `Error: not implemented` message came from calling the Android-only status-bar background-color API on iOS. It occurs after protocol initialization and was not the cause of the startup hang, but this PR removes that unrelated error as well.

## Validation

- reproduced with the latest App Store client, version 3.34.4, on an iPhone 7 Plus running iOS 15.8.5
  - 15 of 20 launches remained on the native launch screen after four seconds
  - one affected launch was still stuck after an additional 30 seconds
- built and installed the patched v3.34.4 source under a separate bundle identifier so the existing app and data were not overwritten
- completed initial setup and launched the patched build successfully 5 consecutive times on the same physical device
- passed 50,000 result-before-wait, wait-before-result, and concurrent actor interleavings
- passed the production Angular build, Capacitor iOS sync, and complete arm64 iOS build

References #218
