### PR TITLE
fix: add haptic feedback for QR scan progress

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-app-launcher')
     implementation project(':capacitor-clipboard')
     implementation project(':capacitor-filesystem')
+    implementation project(':capacitor-haptics')
     implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-status-bar')
     implementation project(':capawesome-capacitor-file-picker')

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -16,6 +16,10 @@
 		"classpath": "com.capacitorjs.plugins.filesystem.FilesystemPlugin"
 	},
 	{
+		"pkg": "@capacitor/haptics",
+		"classpath": "com.capacitorjs.plugins.haptics.HapticsPlugin"
+	},
+	{
 		"pkg": "@capacitor/splash-screen",
 		"classpath": "com.capacitorjs.plugins.splashscreen.SplashScreenPlugin"
 	},

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,6 +14,9 @@ project(':capacitor-clipboard').projectDir = new File('../node_modules/@capacito
 include ':capacitor-filesystem'
 project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
 
+include ':capacitor-haptics'
+project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/haptics/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@capacitor/clipboard": "^6.0.0",
     "@capacitor/core": "^6.0.0",
     "@capacitor/filesystem": "^6.0.0",
+    "@capacitor/haptics": "^6.0.0",
     "@capacitor/ios": "^6.0.0",
     "@capacitor/splash-screen": "^6.0.0",
     "@capacitor/status-bar": "^6.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { RouteReuseStrategy } from '@angular/router'
 import { App } from '@capacitor/app'
 import { AppLauncher } from '@capacitor/app-launcher'
 import { Clipboard } from '@capacitor/clipboard'
+import { Haptics } from '@capacitor/haptics'
 import { SplashScreen } from '@capacitor/splash-screen'
 import { StatusBar } from '@capacitor/status-bar'
 import { FilePicker } from '@capawesome/capacitor-file-picker'
@@ -59,6 +60,7 @@ import {
   CAMERA_PREVIEW_PLUGIN,
   ENVIRONMENT_PLUGIN,
   FILE_PICKER_PLUGIN,
+  HAPTICS_PLUGIN,
   SAPLING_PLUGIN,
   SECURITY_UTILS_PLUGIN
 } from './capacitor-plugins/injection-tokens'
@@ -149,6 +151,7 @@ export function createTranslateLoader(http: HttpClient): AirGapTranslateLoader {
     { provide: CAMERA_PREVIEW_PLUGIN, useValue: CameraPreview },
     { provide: CLIPBOARD_PLUGIN, useValue: Clipboard },
     { provide: FILESYSTEM_PLUGIN, useValue: Filesystem },
+    { provide: HAPTICS_PLUGIN, useValue: Haptics },
     { provide: SAPLING_PLUGIN, useValue: SaplingNative },
     { provide: SECURITY_UTILS_PLUGIN, useValue: SecurityUtils },
     { provide: SPLASH_SCREEN_PLUGIN, useValue: SplashScreen },

--- a/src/app/capacitor-plugins/injection-tokens.ts
+++ b/src/app/capacitor-plugins/injection-tokens.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core'
+import { HapticsPlugin } from '@capacitor/haptics'
 import { FilePickerPlugin } from '@capawesome/capacitor-file-picker'
 import { CameraPreviewPlugin, EnvironmentPlugin, SaplingNativePlugin, SecurityUtilsPlugin } from './definitions'
 
@@ -7,3 +8,4 @@ export const SAPLING_PLUGIN = new InjectionToken<SaplingNativePlugin>('SaplingPl
 export const SECURITY_UTILS_PLUGIN = new InjectionToken<SecurityUtilsPlugin>('SecurityUtilsPlugin')
 export const FILE_PICKER_PLUGIN = new InjectionToken<FilePickerPlugin>('FilePickerPlugin')
 export const ENVIRONMENT_PLUGIN = new InjectionToken<EnvironmentPlugin>('EnvironmentPlugin')
+export const HAPTICS_PLUGIN = new InjectionToken<HapticsPlugin>('HapticsPlugin')

--- a/src/app/pages/contact-book-scan/contact-book-scan.page.ts
+++ b/src/app/pages/contact-book-scan/contact-book-scan.page.ts
@@ -10,6 +10,7 @@ import { ZXingScannerComponent } from '@zxing/ngx-scanner'
 import { NavigationService } from 'src/app/services/navigation/navigation.service'
 import { AddType } from 'src/app/services/contacts/contacts.service'
 import { handleErrorLocal, ErrorCategory } from 'src/app/services/error-handler/error-handler.service'
+import { ScanFeedbackService } from 'src/app/services/scan-feedback/scan-feedback.service'
 
 @Component({
   selector: 'airgap-contact-scan',
@@ -27,9 +28,10 @@ export class ContactBookScanPage extends ScanBasePage {
     @Inject(SECURITY_UTILS_PLUGIN) securityUtils: SecurityUtilsPlugin,
     private readonly iacService: IACService,
     private readonly ngZone: NgZone,
-    private readonly navigationService: NavigationService
+    private readonly navigationService: NavigationService,
+    scanFeedbackService: ScanFeedbackService
   ) {
-    super(platform, scanner, permissionsProvider, securityUtils)
+    super(platform, scanner, permissionsProvider, securityUtils, scanFeedbackService)
   }
 
   public async ionViewWillEnter(): Promise<void> {
@@ -44,6 +46,7 @@ export class ContactBookScanPage extends ScanBasePage {
 
   public async checkScan(data: string): Promise<boolean | void> {
     if (data.length > 0) {
+      this.notifyFrameAccepted()
       const name  = await this.navigationService.getState().name ?? ''
       this.ngZone.run(async () => {
         this.resetScannerPage()

--- a/src/app/pages/scan-base/scan-base.ts
+++ b/src/app/pages/scan-base/scan-base.ts
@@ -5,6 +5,7 @@ import { ZXingScannerComponent } from '@zxing/ngx-scanner'
 import { Observable, ReplaySubject } from 'rxjs'
 import { SecurityUtilsPlugin } from 'src/app/capacitor-plugins/definitions'
 import { SECURITY_UTILS_PLUGIN } from 'src/app/capacitor-plugins/injection-tokens'
+import { ScanFeedbackService } from 'src/app/services/scan-feedback/scan-feedback.service'
 
 export class ScanBasePage {
   public zxingScanner?: ZXingScannerComponent
@@ -24,7 +25,8 @@ export class ScanBasePage {
     protected platform: Platform,
     protected scanner: QrScannerService,
     protected permissionsProvider: PermissionsService,
-    @Inject(SECURITY_UTILS_PLUGIN) private readonly securityUtils: SecurityUtilsPlugin
+    @Inject(SECURITY_UTILS_PLUGIN) private readonly securityUtils: SecurityUtilsPlugin,
+    private readonly scanFeedbackService: ScanFeedbackService
   ) {
     this.isMobile = this.platform.is('hybrid')
     this.isElectron = this.platform.is('electron')
@@ -88,6 +90,10 @@ export class ScanBasePage {
 
   public checkScan(resultString: string): void {
     console.error(`The checkScan method needs to be overwritten. Ignoring text ${resultString}`)
+  }
+
+  protected notifyFrameAccepted(): void {
+    this.scanFeedbackService.notifyFrameAccepted()
   }
 
   private startScanMobile() {

--- a/src/app/pages/tab-scan/tab-scan.page.ts
+++ b/src/app/pages/tab-scan/tab-scan.page.ts
@@ -6,6 +6,7 @@ import { ZXingScannerComponent } from '@zxing/ngx-scanner'
 import { SecurityUtilsPlugin } from 'src/app/capacitor-plugins/definitions'
 import { SECURITY_UTILS_PLUGIN } from 'src/app/capacitor-plugins/injection-tokens'
 import { IACService } from 'src/app/services/iac/iac.service'
+import { ScanFeedbackService } from 'src/app/services/scan-feedback/scan-feedback.service'
 // import { NavigationService } from 'src/app/services/navigation/navigation.service'
 
 import { ErrorCategory, handleErrorLocal } from '../../services/error-handler/error-handler.service'
@@ -34,9 +35,10 @@ export class TabScanPage extends ScanBasePage {
     permissionsProvider: PermissionsService,
     @Inject(SECURITY_UTILS_PLUGIN) securityUtils: SecurityUtilsPlugin,
     private readonly iacService: IACService,
-    private readonly ngZone: NgZone // private readonly navigationService: NavigationService
+    private readonly ngZone: NgZone, // private readonly navigationService: NavigationService
+    scanFeedbackService: ScanFeedbackService
   ) {
-    super(platform, scanner, permissionsProvider, securityUtils)
+    super(platform, scanner, permissionsProvider, securityUtils, scanFeedbackService)
   }
 
   async ionViewWillLeave() {
@@ -69,6 +71,8 @@ export class TabScanPage extends ScanBasePage {
 
       return undefined
     }
+
+    this.notifyFrameAccepted()
 
     this.ngZone.run(() => {
       this.iacService

--- a/src/app/services/scan-feedback/scan-feedback.service.spec.ts
+++ b/src/app/services/scan-feedback/scan-feedback.service.spec.ts
@@ -1,0 +1,34 @@
+import { Haptics, ImpactStyle } from '@capacitor/haptics'
+
+import { ScanFeedbackService } from './scan-feedback.service'
+
+describe('ScanFeedbackService', () => {
+  it('emits a light impact on Android', async () => {
+    const impact = spyOn(Haptics, 'impact').and.returnValue(Promise.resolve())
+    const service = new ScanFeedbackService({ is: (platform: string) => platform === 'android' } as any)
+
+    service.notifyFrameAccepted()
+    await Promise.resolve()
+
+    expect(impact).toHaveBeenCalledWith({ style: ImpactStyle.Light })
+  })
+
+  it('does not emit an impact on non-Android platforms', () => {
+    const impact = spyOn(Haptics, 'impact')
+    const service = new ScanFeedbackService({ is: () => false } as any)
+
+    service.notifyFrameAccepted()
+
+    expect(impact).not.toHaveBeenCalled()
+  })
+
+  it('ignores unavailable haptics without rejecting the scan flow', async () => {
+    spyOn(Haptics, 'impact').and.returnValue(Promise.reject(new Error('Unavailable')))
+    const service = new ScanFeedbackService({ is: () => true } as any)
+
+    service.notifyFrameAccepted()
+    await Promise.resolve()
+
+    expect().nothing()
+  })
+})

--- a/src/app/services/scan-feedback/scan-feedback.service.spec.ts
+++ b/src/app/services/scan-feedback/scan-feedback.service.spec.ts
@@ -1,30 +1,32 @@
-import { Haptics, ImpactStyle } from '@capacitor/haptics'
+import { HapticsPlugin, ImpactStyle } from '@capacitor/haptics'
 
 import { ScanFeedbackService } from './scan-feedback.service'
 
 describe('ScanFeedbackService', () => {
   it('emits a light impact on Android', async () => {
-    const impact = spyOn(Haptics, 'impact').and.returnValue(Promise.resolve())
-    const service = new ScanFeedbackService({ is: (platform: string) => platform === 'android' } as any)
+    const haptics = jasmine.createSpyObj<HapticsPlugin>('Haptics', ['impact'])
+    haptics.impact.and.returnValue(Promise.resolve())
+    const service = new ScanFeedbackService({ is: (platform: string) => platform === 'android' } as any, haptics)
 
     service.notifyFrameAccepted()
     await Promise.resolve()
 
-    expect(impact).toHaveBeenCalledWith({ style: ImpactStyle.Light })
+    expect(haptics.impact).toHaveBeenCalledWith({ style: ImpactStyle.Light })
   })
 
   it('does not emit an impact on non-Android platforms', () => {
-    const impact = spyOn(Haptics, 'impact')
-    const service = new ScanFeedbackService({ is: () => false } as any)
+    const haptics = jasmine.createSpyObj<HapticsPlugin>('Haptics', ['impact'])
+    const service = new ScanFeedbackService({ is: () => false } as any, haptics)
 
     service.notifyFrameAccepted()
 
-    expect(impact).not.toHaveBeenCalled()
+    expect(haptics.impact).not.toHaveBeenCalled()
   })
 
   it('ignores unavailable haptics without rejecting the scan flow', async () => {
-    spyOn(Haptics, 'impact').and.returnValue(Promise.reject(new Error('Unavailable')))
-    const service = new ScanFeedbackService({ is: () => true } as any)
+    const haptics = jasmine.createSpyObj<HapticsPlugin>('Haptics', ['impact'])
+    haptics.impact.and.returnValue(Promise.reject(new Error('Unavailable')))
+    const service = new ScanFeedbackService({ is: () => true } as any, haptics)
 
     service.notifyFrameAccepted()
     await Promise.resolve()

--- a/src/app/services/scan-feedback/scan-feedback.service.ts
+++ b/src/app/services/scan-feedback/scan-feedback.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core'
+import { Haptics, ImpactStyle } from '@capacitor/haptics'
+import { Platform } from '@ionic/angular'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ScanFeedbackService {
+  constructor(private readonly platform: Platform) {}
+
+  public notifyFrameAccepted(): void {
+    if (!this.platform.is('android')) {
+      return
+    }
+
+    void Haptics.impact({ style: ImpactStyle.Light }).catch(() => undefined)
+  }
+}

--- a/src/app/services/scan-feedback/scan-feedback.service.ts
+++ b/src/app/services/scan-feedback/scan-feedback.service.ts
@@ -1,18 +1,20 @@
-import { Injectable } from '@angular/core'
-import { Haptics, ImpactStyle } from '@capacitor/haptics'
+import { Inject, Injectable } from '@angular/core'
+import { HapticsPlugin, ImpactStyle } from '@capacitor/haptics'
 import { Platform } from '@ionic/angular'
+
+import { HAPTICS_PLUGIN } from 'src/app/capacitor-plugins/injection-tokens'
 
 @Injectable({
   providedIn: 'root'
 })
 export class ScanFeedbackService {
-  constructor(private readonly platform: Platform) {}
+  constructor(private readonly platform: Platform, @Inject(HAPTICS_PLUGIN) private readonly haptics: HapticsPlugin) {}
 
   public notifyFrameAccepted(): void {
     if (!this.platform.is('android')) {
       return
     }
 
-    void Haptics.impact({ style: ImpactStyle.Light }).catch(() => undefined)
+    void this.haptics.impact({ style: ImpactStyle.Light }).catch(() => undefined)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,6 +1599,11 @@
   resolved "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-6.0.0.tgz"
   integrity sha512-GnC4CBfky7fvG9zSV/aQnZaGs6ZJ90AaQorr53z81ArTCqcrSUeBMuCxWmvti9HrdXLhBavyA1UOjvRGObOFjg==
 
+"@capacitor/haptics@^6.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@capacitor/haptics/-/haptics-6.0.3.tgz#51229f190a282bd2ad59fdff6352c69db8c5e93c"
+  integrity sha512-6yKF0+lRUZEEx1GDFWgnKHia974np7o1OgmRl/btL9cSMZh0TSDZTyDMH/qcy4AM39CfuIeLs4N4h5lwixXLuQ==
+
 "@capacitor/ios@^6.0.0":
   version "6.1.1"
   resolved "https://registry.npmjs.org/@capacitor/ios/-/ios-6.1.1.tgz"


### PR DESCRIPTION
## Summary

- emit a light Android haptic when a new QR frame is accepted
- apply feedback to the main and contact-book scanners
- ignore unavailable haptics so scanning continues uninterrupted
- inject the Capacitor haptics plugin so behavior can be tested reliably

## Testing

- focused ScanFeedbackService tests: 3 passed
- `yarn build`
- `npx cap sync android`
- `./android/gradlew --no-daemon -p android :app:compileDebugJavaWithJavac`